### PR TITLE
Use Ruby 2.7 for release work

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Ruby 2.6
+      - name: Install Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
       - name: Build gem
         run: gem build *.gemspec

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     if: github.repository == 'voxpupuli/gem-workflow-test'
     steps:
       - uses: actions/checkout@v2
-      - name: Install Ruby 2.6
+      - name: Install Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
       - name: Build gem
         run: gem build *.gemspec
       - name: Publish gem


### PR DESCRIPTION
ba3d56fbad12d00d2caf25b4ab08af86eb88673f switched to using an environment variable, but for that you need rubygems >= 3.0.5.