### PR TITLE
dependabot: also check for gem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  # raise PRs for gem updates
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
I would like to use this gem as an example for our documention on voxpupuli.org, so it should contain the boilerplate we want in every gem.